### PR TITLE
Update organization references to opencadc-metadata-curation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /usr/src/app
 ARG COLLECTION_BRANCH=master
 ARG COLLECTION_REPO=opencadc
 ARG OPENCADC_BRANCH=master
-ARG OPENCADC_REPO=opencadc
+ARG OPENCADC_REPO=opencadc-metadata-curation
 ARG PIPE_BRANCH=master
 ARG PIPE_REPO=opencadc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opencadc/astropy:3.8-slim
+FROM opencadc-metadata-curation/astropy:3.8-slim
 
 RUN apt-get update -y && apt-get install -y \
     build-essential \
@@ -19,11 +19,11 @@ RUN pip install cadcdata \
 WORKDIR /usr/src/app
 
 ARG COLLECTION_BRANCH=master
-ARG COLLECTION_REPO=opencadc
+ARG COLLECTION_REPO=opencadc-metadata-curation
 ARG OPENCADC_BRANCH=master
 ARG OPENCADC_REPO=opencadc-metadata-curation
 ARG PIPE_BRANCH=master
-ARG PIPE_REPO=opencadc
+ARG PIPE_REPO=opencadc-metadata-curation
 
 RUN git clone https://github.com/${OPENCADC_REPO}/caom2tools.git --branch ${OPENCADC_BRANCH} && \
     pip install ./caom2tools/caom2utils

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In an empty directory (the 'working directory'), on a machine with Docker instal
 1. In the master branch of this repository, find the scripts directory, and copy the file `cfht_proc_run.sh` to the working directory. e.g.:
 
   ```
-  wget https://raw.github.com/opencadc/cfhtProc2caom2/master/scripts/cfht_proc_run.sh
+  wget https://raw.github.com/opencadc-metadata-curation/cfhtProc2caom2/master/scripts/cfht_proc_run.sh
   ```
 
 2. Ensure the script is executable:

--- a/scripts/cfht_proc_run.sh
+++ b/scripts/cfht_proc_run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE="opencadc/cfhtproc2caom2"
+IMAGE="opencadc-metadata-curation/cfhtproc2caom2"
 CMD="cfht_proc"
 
 echo "Get a proxy certificate"

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/cfhtProc2caom2
+github_project = opencadc-metadata-curation/cfhtProc2caom2
 install_requires = caom2utils caom2repo cadcdata
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.2.0


### PR DESCRIPTION
This PR updates all references from `opencadc` to `opencadc-metadata-curation` following the repository transfer.

## Changes
- Updated Dockerfile dependencies and base images\n- Updated shell scripts\n
## Files Modified
```
Dockerfile
scripts/cfht_proc_run.sh
```

## Related
- Repository migration to opencadc-metadata-curation organization
- Ensures all references point to the correct organization

## Testing
- Verify builds pass
- Verify all references are updated correctly
