### PR TITLE
Update Dockerfile ARG variables for organization migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /usr/src/app
 ARG COLLECTION_BRANCH=master
 ARG COLLECTION_REPO=opencadc
 ARG OPENCADC_BRANCH=master
-ARG OPENCADC_REPO=opencadc
+ARG OPENCADC_REPO=opencadc-metadata-curation
 ARG PIPE_BRANCH=master
 ARG PIPE_REPO=opencadc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,11 @@ RUN pip install cadcdata \
 WORKDIR /usr/src/app
 
 ARG COLLECTION_BRANCH=master
-ARG COLLECTION_REPO=opencadc
+ARG COLLECTION_REPO=opencadc-metadata-curation
 ARG OPENCADC_BRANCH=master
 ARG OPENCADC_REPO=opencadc-metadata-curation
 ARG PIPE_BRANCH=master
-ARG PIPE_REPO=opencadc
+ARG PIPE_REPO=opencadc-metadata-curation
 
 RUN git clone https://github.com/${OPENCADC_REPO}/caom2tools.git --branch ${OPENCADC_BRANCH} && \
     pip install ./caom2tools/caom2utils

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In an empty directory (the 'working directory'), on a machine with Docker instal
 1. In the master branch of this repository, find the scripts directory, and copy the file `cfht_proc_run.sh` to the working directory. e.g.:
 
   ```
-  wget https://raw.github.com/opencadc/cfhtProc2caom2/master/scripts/cfht_proc_run.sh
+  wget https://raw.github.com/opencadc-metadata-curation/cfhtProc2caom2/master/scripts/cfht_proc_run.sh
   ```
 
 2. Ensure the script is executable:

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/cfhtProc2caom2
+github_project = opencadc-metadata-curation/cfhtProc2caom2
 install_requires = caom2utils caom2repo cadcdata
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.2.0


### PR DESCRIPTION
## Summary
Update Dockerfile ARG variables to reflect the repository transfer from opencadc to opencadc-metadata-curation organization.

## Changes
- Update COLLECTION_REPO from opencadc to opencadc-metadata-curation
- Update PIPE_REPO from opencadc to opencadc-metadata-curation

This ensures pip install commands correctly reference the new repository location:
```
pip install git+https://github.com/opencadc-metadata-curation/caom2pipe
pip install git+https://github.com/opencadc-metadata-curation/cfhtProc2caom2
```

Note: Docker base image references (FROM opencadc/...) remain unchanged as those are still hosted under the opencadc organization.